### PR TITLE
Rename pelican-dev org references to pelican

### DIFF
--- a/docs/panel/advanced/docker.mdx
+++ b/docs/panel/advanced/docker.mdx
@@ -1,6 +1,6 @@
 # Docker
 
-Pelican provides pre-built Docker images via GitHub Packages. `ghcr.io/pelican-dev/panel:latest` is the current latest release, and `ghcr.io/pelican-dev/panel:main` is built automatically from the current `main` branch. Deploying the panel in Docker is still a work in progress. While the plan is to make Docker the preferred installation method, we currently recommend the [standard deployment instructions](/docs/panel/getting-started)
+Pelican provides pre-built Docker images via GitHub Packages. `ghcr.io/pelican/panel:latest` is the current latest release, and `ghcr.io/pelican/panel:main` is built automatically from the current `main` branch. Deploying the panel in Docker is still a work in progress. While the plan is to make Docker the preferred installation method, we currently recommend the [standard deployment instructions](/docs/panel/getting-started)
 
 This guide requires Docker CE. (Docker Compose has been included in the Docker CLI since v2. Docker Compose v1 is unsupported.) For instructions on installing and configuring Docker, see the [installation guide](/docs/guides/docker).
 
@@ -15,7 +15,7 @@ This configuration includes an integrated web server that will automatically obt
 ```yml {17,18} title="compose.yml"
 services:
   panel:
-    image: ghcr.io/pelican-dev/panel:latest
+    image: ghcr.io/pelican/panel:latest
     restart: always
     networks:
       - default
@@ -115,7 +115,7 @@ This example assumes there is a Caddyfile in the same directory as the `compose.
 ```yml {15} title="compose.yml"
 services:
   panel:
-    image: ghcr.io/pelican-dev/panel:latest
+    image: ghcr.io/pelican/panel:latest
     restart: always
     networks:
       - default

--- a/docs/panel/advanced/plugins.mdx
+++ b/docs/panel/advanced/plugins.mdx
@@ -25,7 +25,7 @@ Plugins allow you to add new functionality to the panel without modifying any pa
 
 <Admonition type="info" title="Need some plugins?">
     You can find various official and third party plugins on the [Hub plugin marketplace](https://hub.pelican.dev/plugins)!  
-    Also check out our [Plugins repo](https://github.com/pelican-dev/plugins)! It contains free and open source plugins created by the Pelican team.
+    Also check out our [Plugins repo](https://github.com/pelican/plugins)! It contains free and open source plugins created by the Pelican team.
 </Admonition>
 
 ## Update a Plugin
@@ -328,7 +328,7 @@ public function register(): void
 }
 ```
 
-For more information you can check the ["CanModify" and "CanCustomize" traits in `./app/Traits/Filament`](https://github.com/pelican-dev/panel/tree/main/app/Traits/Filament).
+For more information you can check the ["CanModify" and "CanCustomize" traits in `./app/Traits/Filament`](https://github.com/pelican/panel/tree/main/app/Traits/Filament).
 
 ### Add new permissions
 

--- a/docs/panel/getting-started.mdx
+++ b/docs/panel/getting-started.mdx
@@ -76,7 +76,7 @@ Once you have created a new directory to use and moved into it, you'll need to d
 This is as simple as using `curl` to download the latest release.
 
 ```sh
-curl -L https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz | sudo tar -xzv
+curl -L https://github.com/pelican/panel/releases/latest/download/panel.tar.gz | sudo tar -xzv
 ```
 
 ### Install Composer

--- a/docs/panel/update.mdx
+++ b/docs/panel/update.mdx
@@ -46,7 +46,7 @@ You have two options for updating: use the automatic update script (recommended)
         unpack the archive into your current folder.
 
         ```sh
-        curl -L https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz | sudo tar -xzv
+        curl -L https://github.com/pelican/panel/releases/latest/download/panel.tar.gz | sudo tar -xzv
         ```
 
         Once the archive is downloaded and extracted we need to set the correct permissions on the cache and storage directories to avoid

--- a/docs/wings/install.mdx
+++ b/docs/wings/install.mdx
@@ -76,7 +76,7 @@ run the commands below, which will create the base directory and download the wi
 
 ```sh
 sudo mkdir -p /etc/pelican /var/run/wings
-sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
+sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
 sudo chmod u+x /usr/local/bin/wings
 ```
 

--- a/docs/wings/update.mdx
+++ b/docs/wings/update.mdx
@@ -31,7 +31,7 @@ Updating Wings is a painless process and should take less than a minute to compl
 
         ```sh
         sudo systemctl stop wings
-        sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
+        sudo curl -L -o /usr/local/bin/wings "https://github.com/pelican/wings/releases/latest/download/wings_linux_$([[ "$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "arm64")"
         sudo chmod u+x /usr/local/bin/wings
         ```
     </TabItem>

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   },
   url: "https://pelican.dev",
   baseUrl: "/",
-  organizationName: "pelican-dev",
+  organizationName: "pelican",
   projectName: "docs",
   onBrokenLinks: "throw",
   themes: ["@docusaurus/theme-mermaid"],
@@ -26,7 +26,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
-          editUrl: "https://github.com/pelican-dev/docs/blob/main/",
+          editUrl: "https://github.com/pelican/docs/blob/main/",
           remarkPlugins: [remarkgfm],
         },
         theme: {
@@ -116,7 +116,7 @@ const config: Config = {
         redirects: [
           { from: '/discord', to: 'https://discord.gg/pelican-panel' },
           { from: '/eggs', to: 'https://pelican-eggs.github.io/pelican' },
-          { from: '/github', to: 'https://github.com/pelican-dev/panel' },
+          { from: '/github', to: 'https://github.com/pelican/panel' },
           { from: '/hub', to: 'https://hub.pelican.dev' },
           { from: '/donate', to: 'https://pelican.dev/support' },
         ],

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -45,7 +45,7 @@ Here are some of the most asked questions and our answers.
         <details>
             <summary>Where can I submit bugs and pull requests?</summary>
 
-            They can be posted on our [Github](https://github.com/pelican-dev/panel)!
+            They can be posted on our [Github](https://github.com/pelican/panel)!
         </details>
         <details>
             <summary>Will Blueprint extensions work on Pelican?</summary>
@@ -68,7 +68,7 @@ Here are some of the most asked questions and our answers.
         <details>
             <summary>Where can I submit bugs and pull requests?</summary>
 
-            They can be posted on our [Github](https://github.com/pelican-dev/wings)!
+            They can be posted on our [Github](https://github.com/pelican/wings)!
         </details>
         <details>
             <summary>Will Wings support plugins?</summary>
@@ -108,7 +108,7 @@ Here are some of the most asked questions and our answers.
         <details>
             <summary>Where can I submit feature requests and discuss new ideas?</summary>
 
-            They can be posted on our [Github Discussions](https://github.com/pelican-dev/panel/discussions)
+            They can be posted on our [Github Discussions](https://github.com/pelican/panel/discussions)
         </details>
         <details>
             <summary>Are there any hostilities with the previous project?</summary>
@@ -181,7 +181,7 @@ Here are some of the most asked questions and our answers.
 
             Yes! Everything that was shown as little sneak peaks (+ more!) is available as plugin, for free and open source.
 
-            You can find the official plugin repo [here](https://github.com/pelican-dev/plugins).
+            You can find the official plugin repo [here](https://github.com/pelican/plugins).
         </details>
     </TabItem>
 </Tabs>

--- a/src/pages/support.mdx
+++ b/src/pages/support.mdx
@@ -39,7 +39,7 @@ We really appreciate you, please follow this link to give a one time amount:
 
 <Link
     className="button button--primary text-base"
-    to="https://github.com/sponsors/pelican-dev?frequency=one-time"
+    to="https://github.com/sponsors/pelican?frequency=one-time"
 >Donate One Time</Link>
 
 <hr />

--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -98,8 +98,8 @@ else
 fi
 
 echo "Downloading Files..."
-curl -L https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz -o panel.tar.gz
-expected_checksum=$(curl -L https://github.com/pelican-dev/panel/releases/latest/download/checksum.txt | awk '{ print $1 }')
+curl -L https://github.com/pelican/panel/releases/latest/download/panel.tar.gz -o panel.tar.gz
+expected_checksum=$(curl -L https://github.com/pelican/panel/releases/latest/download/checksum.txt | awk '{ print $1 }')
 calculated_checksum=$(sha256sum panel.tar.gz | awk '{ print $1 }')
 
 if [[ -z "$expected_checksum" || -z "$calculated_checksum" || "$expected_checksum" != "$calculated_checksum" ]]; then


### PR DESCRIPTION
**Do not merge this yet.** Holding it as a draft until the org move is finished, since the new paths don't resolve before then.

The reason this repo is one of the more urgent ones is that a lot of what's in here is stuff people copy and paste straight into a terminal. The panel install and update pages, the wings install and update pages, and `static/updatePanel.sh` all curl release assets off `github.com/pelican-dev/...`, so if any of those go stale someone following the install guide just gets a failed download with no obvious explanation.

`docusaurus.config.ts` has `organizationName` plus the `editUrl` for the "edit this page" links and the `/github` redirect, so those all move too. The Docker page's `ghcr.io/pelican-dev/panel` references are in here as well, though those depend on the images actually being republished under the new namespace first, so it's worth sequencing this one after that's done rather than merging it blind.

Everything else is FAQ and plugins page links, plus the Sponsors link on the support page, which needs the Sponsors profile moved over on GitHub's side before it resolves to anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, update, Docker, plugin, FAQ, and support links to the current project locations.
  * Corrected organization and repository references throughout the documentation and site configuration.
* **Bug Fixes**
  * Updated the Panel update script to download releases and checksums from the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->