### PR TITLE
Fix updater aborting mid-update when the live panel writes into storage/

### DIFF
--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -121,11 +121,18 @@ if [ "$delete_confirm" != "y" ]; then
 fi
 
 echo "Enabling maintenance mode"
-(cd "$install_dir" && php artisan down) || echo "Failed to enable maintenance mode, continuing."
+(cd "$install_dir" && php artisan down)
+if [ $? -ne 0 ]; then
+  echo "Failed to enable maintenance mode, aborting"
+  exit 1
+fi
 
-# storage is excluded: the panel keeps writing logs/sessions into it while this runs,
-# which makes rm -rf fail with "Directory not empty" and abort mid-update
-find "$install_dir" -mindepth 1 -maxdepth 1 ! -name 'backup' ! -name 'plugins' ! -name 'storage' ! -name 'panel.tar.gz' -exec rm -rf {} +
+# The maintenance flag (storage/framework/down) must survive the delete: it stops the
+# live panel from writing logs/sessions into storage mid-delete, which made rm fail
+# with "Directory not empty" and abort the update. Everything else in storage goes too.
+find "$install_dir" -mindepth 1 -maxdepth 1 ! -name 'backup' ! -name 'plugins' ! -name 'storage' ! -name 'panel.tar.gz' -exec rm -rf {} + &&
+find "$install_dir/storage" -mindepth 1 -maxdepth 1 ! -name 'framework' -exec rm -rf {} + &&
+find "$install_dir/storage/framework" -mindepth 1 -maxdepth 1 ! -name 'down' ! -name 'maintenance.php' -exec rm -rf {} +
 if [ $? -ne 0 ]; then
   echo "Failed to delete old files, aborting"
   exit 1

--- a/static/updatePanel.sh
+++ b/static/updatePanel.sh
@@ -120,7 +120,12 @@ if [ "$delete_confirm" != "y" ]; then
   exit 1
 fi
 
-find "$install_dir" -mindepth 1 -maxdepth 1 ! -name 'backup' ! -name 'plugins' ! -name 'panel.tar.gz' -exec rm -rf {} +
+echo "Enabling maintenance mode"
+(cd "$install_dir" && php artisan down) || echo "Failed to enable maintenance mode, continuing."
+
+# storage is excluded: the panel keeps writing logs/sessions into it while this runs,
+# which makes rm -rf fail with "Directory not empty" and abort mid-update
+find "$install_dir" -mindepth 1 -maxdepth 1 ! -name 'backup' ! -name 'plugins' ! -name 'storage' ! -name 'panel.tar.gz' -exec rm -rf {} +
 if [ $? -ne 0 ]; then
   echo "Failed to delete old files, aborting"
   exit 1
@@ -197,6 +202,7 @@ if [ $? -ne 0 ]; then
 fi
 
 php artisan queue:restart
+php artisan up
 
 echo "Panel Updated!"
 echo "If you previously had any themes installed you need to build the panel assets again by manually running \"yarn install\" and \"yarn build\" inside \"$install_dir\"."


### PR DESCRIPTION
Fixes https://github.com/pelican/panel#2536.

## Problem

The auto-updater deletes the install directory while the panel is still running. PHP-FPM, cron, and queue workers keep writing logs/sessions/cache into `storage/` during the `rm -rf`, so `rm` empties a directory, a live process recreates a file inside it, and the final rmdir fails with `rm: cannot remove '/var/www/pelican/storage': Directory not empty`. The script then aborts, after it has already deleted the app, leaving the user with a half-deleted panel to restore by hand.

## Fix

- Exclude `storage/` from the delete step, removing the race target entirely. The tarball extraction merges the new skeleton over it, avatars/fonts in `storage/app/public` survive in place (the existing backup/restore steps remain as a safety net), and `php artisan optimize:clear` already clears stale framework caches.
- Enable maintenance mode (`php artisan down`) before deleting anything, while `vendor/` still exists, and `php artisan up` at the end. The down flag lives in `storage/framework/`, which now survives the delete.

## Testing

- `bash -n static/updatePanel.sh`
- Simulated the race: ran the new `find` delete against a fake install dir while a background loop continuously created files in `storage/logs/`. The delete completes without error and only `backup/` and `storage/` survive; the old exclusion list fails intermittently under the same load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Panel updates now stop safely if maintenance mode cannot be enabled.
  - Maintenance-related files are preserved during storage cleanup.
  - The panel reliably exits maintenance mode after the update and queue restart.
  - Improved update reliability by preventing file deletion conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->