### PR TITLE
Update nginx https config

### DIFF
--- a/docs/panel/webserver-config.mdx
+++ b/docs/panel/webserver-config.mdx
@@ -38,7 +38,8 @@ import TabItem from '@theme/TabItem';
                 }
 
                 server {
-                    listen 443 ssl http2;
+                    listen 443 ssl;
+                    http2 on;
                     server_name <domain>;
 
                     root /var/www/pelican/public;


### PR DESCRIPTION
Added `http2 on;`

https://nginx.org/en/docs/http/ngx_http_v2_module.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Nginx HTTPS configuration example to use the current HTTP/2 directive format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->