### PR TITLE
Support 'toml' format in custom egg documentation

### DIFF
--- a/docs/eggs/creating-a-custom-egg.mdx
+++ b/docs/eggs/creating-a-custom-egg.mdx
@@ -90,6 +90,7 @@ In this example, we are telling Wings to read `server.properties` in `/home/cont
 - `ini`
 - `json` (supports `*` notation)
 - `xml`  (supports `*` notation)
+- `toml`
 
 Once you have defined a parser, we then define a `find` block which tells Wings what specific elements to find and replace. In this example, we have provided four separate items within the `server.properties` file that we want to find and replace to the assigned values. You can use either an exact value, or define a specific server setting from the server configuration. In this case, we're assigning the default server port to be used as the `server.port` and `query.port`. **These placeholders are case sensitive, and should have no spaces in them.**
 


### PR DESCRIPTION
Added 'toml' to the list of supported formats for parsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added TOML as a supported configuration-file parser in the custom egg documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->