### PR TITLE
Fixing docs SSL link

### DIFF
--- a/docs/panel/webserver-config.mdx
+++ b/docs/panel/webserver-config.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 <Admonition type="info">
     When using the SSL (https) configuration you MUST create SSL certificates, otherwise your webserver will fail to start.
-    See the [Creating SSL Certificates](../guides/ssl) documentation page to learn how to create these certificates before continuing.
+    See the [Creating SSL Certificates](/docs/guides/ssl) documentation page to learn how to create these certificates before continuing.
 </Admonition>
 
 <Tabs>


### PR DESCRIPTION
The [Webserver Configuration page](https://pelican.dev/docs/panel/webserver-config/) links to `/docs/panel/guides/ssl`, not the correct `/docs/guides/ssl/`.

The link path was right in code, but relative links may not be processed correctly.  Absolute paths do work as seen on other doc pages (eg. [docker.mdx](https://raw.githubusercontent.com/pelican/docs/refs/heads/main/docs/panel/advanced/docker.mdx)), so I've used that instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Creating SSL Certificates” link to use the correct documentation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->